### PR TITLE
Ignore Metamask messages

### DIFF
--- a/apps/idos-enclave/src/enclave.js
+++ b/apps/idos-enclave/src/enclave.js
@@ -199,6 +199,7 @@ export class Enclave {
   #listenToRequests() {
     window.addEventListener("message", async (event) => {
       if (event.origin !== this.parentOrigin) return;
+      if (event.data.target === "metamask-inpage") return;
 
       try {
         const [requestName, requestData] = Object.entries(event.data).flat();


### PR DESCRIPTION
Show PR.

# Context

I don't know why, but sometimes I was getting messages from Metamask, and it was crashing the enclave.

# How do you know this works?

It stopped crashing.