### PR TITLE
Decode encryption-public-key when retrieving it from store

### DIFF
--- a/apps/idos-enclave/src/enclave.js
+++ b/apps/idos-enclave/src/enclave.js
@@ -30,7 +30,7 @@ export class Enclave {
 
     return {
       humanId: this.store.get("human-id"),
-      encryptionPublicKey: this.store.get("encryption-public-key"),
+      encryptionPublicKey: this.store.pipeCodec(Base64Codec).get("encryption-public-key"),
       signerAddress: this.store.get("signer-address"),
       signerPublicKey: this.store.get("signer-public-key")
     };


### PR DESCRIPTION
This was the only place where we weren't decoding what we get from the store.

This feels like a lapse that was introduced in this commit: https://github.com/idos-network/idos-sdk-js/commit/a3a8fe3a3b5a855b768a3e472bb06e178db4ac65#diff-1ceb294560de58ea95acc4e49ad7281546107803b85dd00891d04d14a253b95eR33