### PR TITLE
fix: do not initailise enclave when deleting records

### DIFF
--- a/packages/idos-sdk-js/src/lib/data.ts
+++ b/packages/idos-sdk-js/src/lib/data.ts
@@ -147,7 +147,7 @@ export class Data {
     return record || null;
   }
 
-  async delete(tableName: string, recordId: string): Promise<{ id: string }> {    
+  async delete(tableName: string, recordId: string): Promise<{ id: string }> {
     const record = { id: recordId };
     await this.idOS.kwilWrapper.broadcast(`remove_${this.singularize(tableName)}`, record);
 


### PR DESCRIPTION
When removing records, there is no need to initialise the enclave.