### PR TITLE
fix(idos-sdk-js): make idOS.verifiableCredentials.verify more configurable

### DIFF
--- a/packages/idos-sdk-js/src/__tests__/crypto.test.js
+++ b/packages/idos-sdk-js/src/__tests__/crypto.test.js
@@ -1,7 +1,0 @@
-import { expect, test } from "vitest";
-import { Crypto } from "../lib/crypto";
-
-test("instantiates a `Crypto` instance", () => {
-  const crypto = new Crypto({});
-  expect(crypto).toBeDefined();
-});

--- a/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
+++ b/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 
 import { documentLoader } from "./cachedSchemas";
 
-import verifiedCredential from "../lib/verifiable-credentials";
+import verifiedCredentials from "../lib/verifiable-credentials";
 
 test("verifies an example credential", async () => {
   const credential = {
@@ -38,5 +38,5 @@ test("verifies an example credential", async () => {
     }
   };
 
-  expect(await verifiedCredential.verify(credential, { documentLoader })).toBe(true);
+  expect(await verifiedCredentials.verify(credential, { documentLoader })).toBe(true);
 });

--- a/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
+++ b/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 
 import { documentLoader } from "./cachedSchemas";
 
-import * as verifiedCredentials from "../lib/verifiable-credentials";
+import * as verifiableCredentials from "../lib/verifiable-credentials";
 
 test("verifies an example credential", async () => {
   const credential = {
@@ -43,10 +43,10 @@ test("verifies an example credential", async () => {
   };
 
   expect(
-    await verifiedCredentials.verify(credential, {
-      documentLoader: verifiedCredentials.documentLoaderWithFallbackCompose(
+    await verifiableCredentials.verify(credential, {
+      documentLoader: verifiableCredentials.documentLoaderWithFallbackCompose(
         documentLoader,
-        verifiedCredentials.staticLoader(
+        verifiableCredentials.staticLoader(
           "https://vc-issuers.fractal.id/idos",
           "z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2"
         )

--- a/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
+++ b/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
@@ -4,44 +4,44 @@ import { documentLoader } from "./cachedSchemas";
 
 import * as verifiableCredentials from "../lib/verifiable-credentials";
 
-test("verifies an example credential", async () => {
-  const credential = {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/verifiable_credential/fractal_id.json-ld",
-      "https://w3id.org/security/suites/ed25519-2020/v1",
+const credential = {
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/verifiable_credential/fractal_id.json-ld",
+    "https://w3id.org/security/suites/ed25519-2020/v1",
+  ],
+  id: "uuid:ddedb27a-0a7f-48ac-baa7-848631918d6e",
+  type: ["VerifiableCredential"],
+  issuer: "https://vc-issuers.fractal.id/idos",
+  issuanceDate: "2023-10-05T12:37:35Z",
+  level: "basic",
+  status: "approved",
+  approved_at: "2023-10-05T12:37:35Z",
+  credentialSubject: {
+    id: "uuid:f149f600-418b-4481-9efb-01c0ef72d8ba",
+    wallets: [
+      { currency: "near", verified: true, address: "example.testnet" },
+      {
+        currency: "eth",
+        verified: true,
+        address: "0x05a56f2d52c817161883f50c441c3228cfe54d9f",
+      },
     ],
-    id: "uuid:ddedb27a-0a7f-48ac-baa7-848631918d6e",
-    type: ["VerifiableCredential"],
-    issuer: "https://vc-issuers.fractal.id/idos",
-    issuanceDate: "2023-10-05T12:37:35Z",
-    level: "basic",
-    status: "approved",
-    approved_at: "2023-10-05T12:37:35Z",
-    credentialSubject: {
-      id: "uuid:f149f600-418b-4481-9efb-01c0ef72d8ba",
-      wallets: [
-        { currency: "near", verified: true, address: "example.testnet" },
-        {
-          currency: "eth",
-          verified: true,
-          address: "0x05a56f2d52c817161883f50c441c3228cfe54d9f",
-        },
-      ],
-      emails: ["email@example.com"],
-    },
-    proof: {
-      type: "Ed25519Signature2020",
-      created: "2023-10-20T18:02:40Z",
-      verificationMethod:
-        "https://vc-issuers.fractal.id/idos#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2",
-      proofPurpose: "assertionMethod",
-      "@context": ["https://www.w3.org/ns/credentials/v2"],
-      proofValue:
-        "z4ucudi8ihgid5aUPotF7M5wHCH5C6ZGQJwkvjWMvjSYL5kYqkHEF9WZ1nZBDcJzkTh7zmL2HEtLzmEAiveW28wsT",
-    },
-  };
+    emails: ["email@example.com"],
+  },
+  proof: {
+    type: "Ed25519Signature2020",
+    created: "2023-10-20T18:02:40Z",
+    verificationMethod:
+      "https://vc-issuers.fractal.id/idos#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2",
+    proofPurpose: "assertionMethod",
+    "@context": ["https://www.w3.org/ns/credentials/v2"],
+    proofValue:
+      "z4ucudi8ihgid5aUPotF7M5wHCH5C6ZGQJwkvjWMvjSYL5kYqkHEF9WZ1nZBDcJzkTh7zmL2HEtLzmEAiveW28wsT",
+  },
+};
 
+test("verifies an example credential", async () => {
   expect(
     await verifiableCredentials.verify(credential, {
       documentLoader: verifiableCredentials.documentLoaderWithFallbackCompose(
@@ -53,4 +53,25 @@ test("verifies an example credential", async () => {
       ),
     })
   ).toBe(true);
+});
+
+test("needs the multibase key to exist", async () => {
+  // Note how we're not adding a static loader for z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2, which is what's
+  // being used in `credential`.
+  expect(
+    await verifiableCredentials
+      .verify(credential, { documentLoader })
+      .catch((e) => e)
+  ).toMatchObject({
+    verified: false,
+    error: {
+      message: "Verification error(s).",
+      errors: [
+        {
+          message:
+            "Did not verify any proofs; insufficient proofs matched the acceptable suite(s) and required purpose(s).",
+        },
+      ],
+    },
+  });
 });

--- a/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
+++ b/packages/idos-sdk-js/src/__tests__/verifiable-credentials.test.js
@@ -2,14 +2,14 @@ import { expect, test } from "vitest";
 
 import { documentLoader } from "./cachedSchemas";
 
-import verifiedCredentials from "../lib/verifiable-credentials";
+import * as verifiedCredentials from "../lib/verifiable-credentials";
 
 test("verifies an example credential", async () => {
   const credential = {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/verifiable_credential/fractal_id.json-ld",
-      "https://w3id.org/security/suites/ed25519-2020/v1"
+      "https://w3id.org/security/suites/ed25519-2020/v1",
     ],
     id: "uuid:ddedb27a-0a7f-48ac-baa7-848631918d6e",
     type: ["VerifiableCredential"],
@@ -22,9 +22,13 @@ test("verifies an example credential", async () => {
       id: "uuid:f149f600-418b-4481-9efb-01c0ef72d8ba",
       wallets: [
         { currency: "near", verified: true, address: "example.testnet" },
-        { currency: "eth", verified: true, address: "0x05a56f2d52c817161883f50c441c3228cfe54d9f" }
+        {
+          currency: "eth",
+          verified: true,
+          address: "0x05a56f2d52c817161883f50c441c3228cfe54d9f",
+        },
       ],
-      emails: ["email@example.com"]
+      emails: ["email@example.com"],
     },
     proof: {
       type: "Ed25519Signature2020",
@@ -34,9 +38,19 @@ test("verifies an example credential", async () => {
       proofPurpose: "assertionMethod",
       "@context": ["https://www.w3.org/ns/credentials/v2"],
       proofValue:
-        "z4ucudi8ihgid5aUPotF7M5wHCH5C6ZGQJwkvjWMvjSYL5kYqkHEF9WZ1nZBDcJzkTh7zmL2HEtLzmEAiveW28wsT"
-    }
+        "z4ucudi8ihgid5aUPotF7M5wHCH5C6ZGQJwkvjWMvjSYL5kYqkHEF9WZ1nZBDcJzkTh7zmL2HEtLzmEAiveW28wsT",
+    },
   };
 
-  expect(await verifiedCredentials.verify(credential, { documentLoader })).toBe(true);
+  expect(
+    await verifiedCredentials.verify(credential, {
+      documentLoader: verifiedCredentials.documentLoaderWithFallbackCompose(
+        documentLoader,
+        verifiedCredentials.staticLoader(
+          "https://vc-issuers.fractal.id/idos",
+          "z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2"
+        )
+      ),
+    })
+  ).toBe(true);
 });

--- a/packages/idos-sdk-js/src/lib/verifiable-credentials.d.ts
+++ b/packages/idos-sdk-js/src/lib/verifiable-credentials.d.ts
@@ -1,3 +1,3 @@
-const verify = async (credential: object | string, options = {}) => Promise<true>;
+export const verify = async (credential: object | string, options = {}) => Promise<true>;
 
 export default { verify };

--- a/packages/idos-sdk-js/src/lib/verifiable-credentials.js
+++ b/packages/idos-sdk-js/src/lib/verifiable-credentials.js
@@ -49,9 +49,9 @@ export const documentLoaderWithStaticFractal = (documentLoader) => async (url, o
 };
 
 const knownSignatureBuilders = {
-  Ed25519VerificationKey2020: async (m) =>
+  Ed25519VerificationKey2020: async (method) =>
     new Ed25519Signature2020({
-      key: await Ed25519VerificationKey2020.from(m)
+      key: await Ed25519VerificationKey2020.from(method)
     })
 };
 

--- a/packages/idos-sdk-js/src/lib/verifiable-credentials.js
+++ b/packages/idos-sdk-js/src/lib/verifiable-credentials.js
@@ -38,7 +38,7 @@ export const staticLoader = (id, publicKeyMultibase) => {
 
 export const staticFractalLoader = staticLoader(FRACTAL_ISSUER, FRACTAL_PUBLIC_KEY_MULTIBASE);
 
-const xhrLoader = (jsonld.documentLoaders.xhr ?? jsonld.documentLoaders.node)();
+export const defaultLoader = (jsonld.documentLoaders.xhr ?? jsonld.documentLoaders.node)();
 
 export const documentLoaderWithFallbackCompose = (documentLoaderA, documentLoaderB) => async (url, options = {}) => {
   let ex;
@@ -100,7 +100,7 @@ export const verify = async (credential, options = {}) => {
   let { allowedSigners, allowedIssuers, signatureBuilders, documentLoader } = options;
   if (!signatureBuilders) signatureBuilders = knownSignatureBuilders;
   if (!allowedIssuers) allowedIssuers = [FRACTAL_ISSUER];
-  if (!documentLoader) documentLoader = xhrLoader;
+  if (!documentLoader) documentLoader = defaultLoader;
 
   documentLoader = documentLoaderWithStaticFractal(documentLoader);
 


### PR DESCRIPTION
Sanity-check PR.

# Context

I was trying to help an integrator work with https://app.next.fractal.id/, where we use a different multibase key from prod. However, the current implementation of verify doesn't have any good way of supporting that.

# Solution

Compose our static document resolver in a slightly different way, and expose those methods to whomever wants to do the similar workarounds. In the process of doing this, I realized we also needed that for our tests, that was passing locally only because I happened to have the right values in my `.env.local`.

# Known problems

I didn't update the TS signature files. json-ld is not typed, it's not easy to type, and I don't think it's worth our time to type these helpers. PRs would be welcome, if anybody ever wants to put the work in.