### PR TITLE
Introduce implicitAddressFromPublicKey

### DIFF
--- a/packages/idos-sdk-js/src/lib/auth.ts
+++ b/packages/idos-sdk-js/src/lib/auth.ts
@@ -10,7 +10,7 @@ import { SigningKey, hashMessage } from "ethers";
 
 import { idOS } from "./idos";
 import { Nonce } from "./nonce";
-import { getNearImplicitAddress } from "./utils";
+import { implicitAddressFromPublicKey } from "./utils";
 
 /* global Buffer */
 
@@ -176,9 +176,8 @@ export class Auth {
       );
     };
 
-    const implicitAccount = await getNearImplicitAddress(currentAddress);
     return this.#setSigner({
-      accountId: implicitAccount,
+      accountId: implicitAddressFromPublicKey(publicKey),
       signer,
       publicKey,
       signatureType: "nep413"

--- a/packages/idos-sdk-js/src/lib/utils.ts
+++ b/packages/idos-sdk-js/src/lib/utils.ts
@@ -25,10 +25,7 @@ export async function getNearFullAccessPublicKey(namedAddress: string) {
   }
 }
 
-export async function getNearImplicitAddress(namedAddress: string) {
-  const publicKey = await getNearFullAccessPublicKey(namedAddress);
-  if (!publicKey) return;
-
+export function implicitAddressFromPublicKey(publicKey: string) {
   const key_without_prefix = publicKey.replace(/^ed25519:/, "");
   const implicitAddress = toBeHex(decodeBase58(key_without_prefix));
   return implicitAddress;


### PR DESCRIPTION
We don't need to fetch a new public key from the network, we already got one from signing.