### PR TITLE
feat: better chainId discovery

### DIFF
--- a/apps/idos-data-dashboard/src/core/idos.tsx
+++ b/apps/idos-data-dashboard/src/core/idos.tsx
@@ -82,7 +82,9 @@ export const Provider = ({ children }: PropsWithChildren) => {
     if (!signer || !userAddress) return;
 
     const _sdk = await idOS.init({
-      container: "#idos"
+      container: "#idos",
+      nodeUrl: import.meta.env.VITE_IDOS_NODE_URL,
+      dbId: import.meta.env.VITE_IDOS_NODE_KWIL_DB_ID
     });
 
     const profile = await _sdk.hasProfile(userAddress);

--- a/packages/idos-sdk-js/src/lib/idos.ts
+++ b/packages/idos-sdk-js/src/lib/idos.ts
@@ -55,8 +55,8 @@ export class idOS {
     this.initializeKwilWrapper({ nodeUrl, dbId });
   }
 
-  async initializeKwilWrapper({ nodeUrl, dbId }) {
-    const kwil = new WebKwil({ kwilProvider: KwilWrapper.defaults.kwilProvider, chainId: "" });
+  async initializeKwilWrapper({ nodeUrl = KwilWrapper.defaults.kwilProvider, dbId }) {
+    const kwil = new WebKwil({ kwilProvider: nodeUrl, chainId: "" });
     const chainId = (await kwil.chainInfo()).data?.chain_id;
     this.kwilWrapper = new KwilWrapper({ nodeUrl, dbId, chainId });
   }


### PR DESCRIPTION
- Don't use the `KwilWrapper.defaults.kwilProvider` to discover `chainId` 
- Avoid data races and stand-in values
- Use `.env` variables for the Dashboard initialisation

This already bit a user, so let's make sure we fix it.