### PR TITLE
fix: support errors on getNearFullAccessPublicKeys

### DIFF
--- a/apps/idos-data-dashboard/src/routes/dashboard/wallets/components/add-wallet.tsx
+++ b/apps/idos-data-dashboard/src/routes/dashboard/wallets/components/add-wallet.tsx
@@ -101,7 +101,7 @@ export const AddWallet = ({ isOpen, onClose }: AddWalletProps) => {
     if (address_type === "NEAR") {
       publicKeys = await getNearFullAccessPublicKeys(address);
 
-      if (publicKeys.length === 0) {
+      if (!publicKeys?.length) {
         toast({
           title: "Error while adding wallet",
           description:

--- a/apps/idos-data-dashboard/src/routes/dashboard/wallets/components/add-wallet.tsx
+++ b/apps/idos-data-dashboard/src/routes/dashboard/wallets/components/add-wallet.tsx
@@ -99,9 +99,9 @@ export const AddWallet = ({ isOpen, onClose }: AddWalletProps) => {
     let publicKeys: string[] = [];
 
     if (address_type === "NEAR") {
-      publicKeys = await getNearFullAccessPublicKeys(address);
+      publicKeys = (await getNearFullAccessPublicKeys(address)) || [];
 
-      if (!publicKeys?.length) {
+      if (!publicKeys.length) {
         toast({
           title: "Error while adding wallet",
           description:

--- a/packages/idos-sdk-js/src/lib/utils.ts
+++ b/packages/idos-sdk-js/src/lib/utils.ts
@@ -1,7 +1,9 @@
 import { decodeBase58, toBeHex } from "ethers";
 import * as nearAPI from "near-api-js";
 
-export async function getNearFullAccessPublicKeys(namedAddress: string) {
+export async function getNearFullAccessPublicKeys(
+  namedAddress: string
+): Promise<string[] | undefined> {
   const { connect } = nearAPI;
   const connectionConfig = {
     networkId: import.meta.env.VITE_IDOS_NEAR_DEFAULT_NETWORK,


### PR DESCRIPTION
When it's given a non-NEAR address, it just returns null. Let's cover that case.