### PR TITLE
chore: just consider crypto exists

### DIFF
--- a/packages/idos-sdk-js/src/lib/data.ts
+++ b/packages/idos-sdk-js/src/lib/data.ts
@@ -1,6 +1,8 @@
 import * as Base64Codec from "@stablelib/base64";
 import { idOS } from "./idos";
 
+/* global crypto */
+
 export class Data {
   idOS: idOS;
 

--- a/packages/idos-sdk-js/src/lib/idos-grantee.ts
+++ b/packages/idos-sdk-js/src/lib/idos-grantee.ts
@@ -12,10 +12,9 @@ import { assertNever } from "../types";
 import { KwilWrapper } from "./kwil-wrapper";
 import { implicitAddressFromPublicKey } from "./utils";
 
-export type WalletType = "EVM" | "NEAR";
+/* global crypto */
 
-const crypto =
-  typeof window === "undefined" ? (await import("node:crypto")).default : window.crypto;
+export type WalletType = "EVM" | "NEAR";
 
 const kwilNep413Signer =
   (recipient: string) =>


### PR DESCRIPTION
I think we don't need to import anything.

```bash
$ node
Welcome to Node.js v18.19.0.
Type ".help" for more information.
> crypto.getRandomValues
[Function: getRandomValues]
```

And, it's in your window too:
![image](https://github.com/idos-network/idos-sdk-js/assets/9627/39f3754f-f4cf-4e2b-a229-9ac84eaf5a62)
