### PR TITLE
chore: rename init to ready

### DIFF
--- a/packages/idos-sdk-js/src/lib/data.ts
+++ b/packages/idos-sdk-js/src/lib/data.ts
@@ -48,7 +48,7 @@ export class Data {
     let receiverPublicKey;
 
     if (tableName === "credentials") {
-      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.init());
+      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.ready());
       for (const record of records) {
         (record as any).content = await this.idOS.enclave.encrypt(
           (record as any).content as string,
@@ -59,7 +59,7 @@ export class Data {
     }
 
     if (tableName === "attributes") {
-      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.init());
+      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.ready());
       for (const record of records) {
         (record as any).value = await this.idOS.enclave.encrypt(
           (record as any).value as string,
@@ -102,7 +102,7 @@ export class Data {
     }
 
     if (tableName === "credentials") {
-      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.init());
+      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.ready());
       (record as any).content = await this.idOS.enclave.encrypt(
         (record as any).content as string,
         receiverPublicKey
@@ -111,7 +111,7 @@ export class Data {
     }
 
     if (tableName === "attributes") {
-      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.init());
+      receiverPublicKey = receiverPublicKey ?? Base64Codec.encode(await this.idOS.enclave.ready());
       (record as any).value = await this.idOS.enclave.encrypt(
         (record as any).value as string,
         receiverPublicKey
@@ -235,7 +235,7 @@ export class Data {
     description?: string,
     synchronous?: boolean
   ): Promise<T> {
-    if (!this.idOS.enclave.initialized) await this.idOS.enclave.init();
+    if (!this.idOS.enclave.readied) await this.idOS.enclave.ready();
 
     if (tableName === "credentials") {
       record.content = await this.idOS.enclave.encrypt(record.content);
@@ -260,7 +260,7 @@ export class Data {
     recordId: string,
     receiverPublicKey: string
   ): Promise<{ id: string }> {
-    const encPublicKey = Base64Codec.encode(await this.idOS.enclave.init());
+    const encPublicKey = Base64Codec.encode(await this.idOS.enclave.ready());
 
     const name = this.singularize(tableName);
 

--- a/packages/idos-sdk-js/src/lib/enclave-providers/iframe-enclave.ts
+++ b/packages/idos-sdk-js/src/lib/enclave-providers/iframe-enclave.ts
@@ -17,7 +17,7 @@ export class IframeEnclave implements EnclaveProvider {
     return (await this.#requestToEnclave({ storage: {} })) as StoredData;
   }
 
-  async init(
+  async ready(
     humanId?: string,
     signerAddress?: string,
     signerPublicKey?: string,

--- a/packages/idos-sdk-js/src/lib/enclave-providers/interface.ts
+++ b/packages/idos-sdk-js/src/lib/enclave-providers/interface.ts
@@ -7,7 +7,7 @@ export interface StoredData {
 
 export interface EnclaveProvider {
   load(): Promise<StoredData>;
-  init(
+  ready(
     humanId?: string,
     signerAddress?: string,
     signerPublicKey?: string,

--- a/packages/idos-sdk-js/src/lib/enclave-providers/metamask-snap-enclave.ts
+++ b/packages/idos-sdk-js/src/lib/enclave-providers/metamask-snap-enclave.ts
@@ -25,7 +25,7 @@ export class MetaMaskSnapEnclave implements EnclaveProvider {
     return storage;
   }
 
-  async init(
+  async ready(
     humanId?: string,
     signerAddress?: string,
     signerPublicKey?: string


### PR DESCRIPTION
Show PR for https://github.com/idos-network/idos-sdk-js/issues/173.

This one pains me a little bit. `ready` and `init` sound like synonyms. However, I really want to enforce the expectations around the name `init`, I don't have a better at hand, and this is not part of the public API.

In order to self-ship, I'll have to see this decrypting the contents of an current credential.