### PR TITLE
feat: expose dAG message methods through `grants`

### DIFF
--- a/packages/idos-sdk-js/src/lib/grants/grants.ts
+++ b/packages/idos-sdk-js/src/lib/grants/grants.ts
@@ -180,4 +180,12 @@ class ConnectedGrants extends Grants {
 
     return this.#child.revoke({ grantee, dataId, lockedUntil });
   }
+
+  async messageForCreateBySignature(grant: Grant) {
+    return this.#child.messageForCreateBySignature(grant);
+  }
+
+  async messageForRevokeBySignature(grant: Grant) {
+    return this.#child.messageForRevokeBySignature(grant);
+  }
 }


### PR DESCRIPTION
Exposes `messageForCreateBySignature` and `messageForRevokeBySignature` through the SDK .