### PR TITLE
chore: remove `setHumanId` optimization

### DIFF
--- a/packages/idos-sdk-js/src/lib/auth.ts
+++ b/packages/idos-sdk-js/src/lib/auth.ts
@@ -180,13 +180,6 @@ export class Auth {
     return args;
   }
 
-  async setHumanId(humanId: string) {
-    if (!humanId) return;
-
-    this.user.humanId = humanId;
-    await this.remember("human-id", humanId);
-  }
-
   async currentUser() {
     if (this.user.humanId === undefined) {
       const currentUserKeys = ["human-id", "signer-address", "signer-public-key"];

--- a/packages/idos-sdk-js/src/lib/data.ts
+++ b/packages/idos-sdk-js/src/lib/data.ts
@@ -24,8 +24,6 @@ export class Data {
       `List your ${tableName} in idOS`
     )) as any;
 
-    await this.idOS.auth.setHumanId(records[0]?.human_id);
-
     if (tableName === "attributes") {
       for (const record of records) {
         record.value = await this.idOS.enclave.decrypt(record.value);
@@ -140,8 +138,6 @@ export class Data {
         { id: recordId },
         "Get your credential in idOS"
       )) as any;
-
-      await this.idOS.auth.setHumanId(records?.[0]?.human_id);
 
       const record = records.find((r: { id: string }) => r.id === recordId);
 


### PR DESCRIPTION
Show PR.

This used to be a useful shortcut to discover `human_id` when we required a signature on every read call to Kwil. Now that we're using kgw's cookie auth, we always need a signature, and we re-use that one for all reads.

Removing this buys having less dependencies (and therefore easier-to-test things).