### PR TITLE
chore: easier APIs

### DIFF
--- a/packages/idos-sdk-js/src/lib/enclave.ts
+++ b/packages/idos-sdk-js/src/lib/enclave.ts
@@ -54,14 +54,13 @@ export class Enclave {
   }
 
   async ready(): Promise<Uint8Array> {
-    const signerAddress = this.idOS.store.get("signer-address");
-    const signerPublicKey = this.idOS.store.get("signer-public-key");
+    const { humanId, address, publicKey } = await this.idOS.auth.currentUser();
 
-    const humanId = (await this.idOS.auth.currentUser()).humanId;
+    if (!humanId) {
+      throw new Error("Can't operate on a user that has no profile.");
+    }
 
-    if (!humanId) throw new Error("Could not initialize user.");
-
-    this.encryptionPublicKey = await this.provider.ready(humanId, signerAddress, signerPublicKey);
+    this.encryptionPublicKey = await this.provider.ready(humanId, address, publicKey);
     this.idOS.store.set("encryption-public-key", Base64Codec.encode(this.encryptionPublicKey));
     this.readied = true;
 


### PR DESCRIPTION
Show PR.

- Still uses the same memory, but leans on previous loading points.
- Cleaner expectations on `idos.auth.user`
- Actually fulfill the API that's on the README :sweat_smile: 