### PR TITLE
feat: a more sensible enclave unlocking flow

### DIFF
--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -297,7 +297,7 @@ export class Enclave {
     const dialogURL = new URL("/dialog.html", window.location.origin);
     this.dialog = window.open(dialogURL, "idos-dialog", popupConfig);
 
-    await new Promise((resolve) => this.dialog.addEventListener("load", resolve));
+    await new Promise((resolve) => this.dialog.addEventListener("ready", resolve, { once: true }));
 
     return new Promise((resolve, reject) => {
       const { port1, port2 } = new MessageChannel();

--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -39,9 +39,8 @@ export class Enclave {
     };
   }
 
-  async keys(authMethod) {
+  async keys() {
     try {
-      if (authMethod) await this.#openDialog("auth");
       await this.ensurePassword();
       await this.ensureKeyPair();
     } catch (e) {
@@ -232,7 +231,6 @@ export class Enclave {
           senderPublicKey,
           signerAddress,
           signerPublicKey,
-          authMethod,
           mode,
           theme,
         } = requestData;
@@ -241,7 +239,7 @@ export class Enclave {
           confirm: () => [message],
           decrypt: () => [fullMessage, senderPublicKey],
           encrypt: () => [message, receiverPublicKey],
-          keys: () => [authMethod],
+          keys: () => [],
           reset: () => [],
           configure: () => [mode, theme],
           storage: () => [humanId, signerAddress, signerPublicKey],

--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -45,9 +45,8 @@ export class Enclave {
       await this.ensureKeyPair();
     } catch (e) {
       console.warn(e);
-    } finally {
-      return this.keyPair?.publicKey;
     }
+    return this.keyPair?.publicKey;
   }
 
   async authWithPassword() {

--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -40,12 +40,9 @@ export class Enclave {
   }
 
   async keys() {
-    try {
-      await this.ensurePassword();
-      await this.ensureKeyPair();
-    } catch (e) {
-      console.warn(e);
-    }
+    await this.ensurePassword();
+    await this.ensureKeyPair();
+
     return this.keyPair?.publicKey;
   }
 

--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -65,7 +65,7 @@ export class Enclave {
     let credentialId;
 
     const getWebAuthnCredential = async (storedCredentialId) => {
-      const credentialRequest = {
+      const credentialRequestWithId = {
         publicKey: {
           challenge: crypto.getRandomValues(new Uint8Array(10)),
           allowCredentials: [
@@ -74,65 +74,67 @@ export class Enclave {
               id: Base64Codec.decode(storedCredentialId),
             },
           ],
-          authenticatorSelection: {
-            authenticatorAttachment: "platform",
-            userVerification: "required",
-            residentKey: "preferred",
-          },
         },
       };
 
-      const credential = await navigator.credentials.get(credentialRequest);
+      const credential = await navigator.credentials.get(credentialRequestWithId);
       password = Utf8Codec.decode(new Uint8Array(credential.response.userHandle));
       credentialId = Base64Codec.encode(new Uint8Array(credential.rawId));
+
       return { password, credentialId };
     };
 
-    return new Promise((resolve) =>
+    return new Promise((resolve, reject) =>
       this.unlockButton.addEventListener("click", async () => {
         this.unlockButton.disabled = true;
 
-        const preferredAuthMethod = this.store.get("preferred-auth-method");
+        const storedCredentialId = this.store.get("credential-id");
 
-        if (preferredAuthMethod === "password") {
-          ({ password, duration } = await this.#openDialog("password"));
-          this.store.set("password", password);
-          this.store.setRememberDuration(duration);
-          return resolve();
-        }
+        if (storedCredentialId) {
+          try {
+            ({ password, credentialId } = await getWebAuthnCredential(storedCredentialId));
+          } catch (e) {
+            console.warn(e);
+            return reject();
+          }
+        } else {
+          const preferredAuthMethod = this.store.get("preferred-auth-method");
 
-        if (preferredAuthMethod === "webauthn") {
-          const storedCredentialId = this.store.get("credential-id");
-
-          if (storedCredentialId) {
+          if (preferredAuthMethod === "password") {
             try {
-              ({ password, credentialId } = await getWebAuthnCredential(storedCredentialId));
+              ({ password, duration } = await this.#openDialog("password"));
             } catch (e) {
-              ({ password, credentialId } = await this.#openDialog("passkey", {
-                type: "webauthn",
-              }));
+              console.warn(e);
+              return reject();
+            }
+          } else if (preferredAuthMethod === "passkey") {
+            try {
+              ({ password, credentialId } = await this.#openDialog("passkey", { type: "webauthn" }));
+            } catch (e) {
+              console.warn(e);
+              return reject();
             }
           } else {
-            ({ password, credentialId } = await this.#openDialog("passkey", {
-              type: "webauthn",
-            }));
+            try {
+              ({ password, duration, credentialId } = await this.#openDialog("auth"));
+            } catch (e) {
+              console.warn(e);
+              return reject();
+            }
           }
-          this.store.set("credential-id", credentialId);
-          this.store.set("password", password);
-          return resolve();
         }
 
-        ({ password, duration, credentialId } = await this.#openDialog("auth"));
+        this.store.set("password", password);
 
         if (credentialId) {
           this.store.set("credential-id", credentialId);
           this.store.set("preferred-auth-method", "webauthn");
         } else {
           this.store.set("preferred-auth-method", "password");
+          this.store.setRememberDuration(duration);
         }
-        this.store.set("password", password);
-        this.store.setRememberDuration(duration);
-        resolve();
+
+        return password ? resolve() : reject();
       }),
     );
   }
@@ -267,7 +269,7 @@ export class Enclave {
         const response = await this[requestName](...paramBuilder());
         event.ports[0].postMessage({ result: response });
       } catch (error) {
-        console.log("catch", error);
+        console.warn("catch", error);
         event.ports[0].postMessage({ error });
       } finally {
         this.unlockButton.style.display = "none";

--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -109,7 +109,9 @@ export class Enclave {
             }
           } else if (preferredAuthMethod === "passkey") {
             try {
-              ({ password, credentialId } = await this.#openDialog("passkey", { type: "webauthn" }));
+              ({ password, credentialId } = await this.#openDialog("passkey", {
+                type: "webauthn",
+              }));
             } catch (e) {
               console.warn(e);
               return reject();

--- a/apps/idos-enclave/src/pages/App.tsx
+++ b/apps/idos-enclave/src/pages/App.tsx
@@ -129,7 +129,7 @@ export function App({ store, enclave }: AppProps) {
   }, []);
 
   const onError = useCallback((error: any) => {
-    respondToEnclave({ error: error.toSring() });
+    respondToEnclave({ error: error.toString() });
   }, []);
 
   const methodProps = {

--- a/apps/idos-enclave/src/pages/App.tsx
+++ b/apps/idos-enclave/src/pages/App.tsx
@@ -119,6 +119,8 @@ export function App({ store, enclave }: AppProps) {
     window.addEventListener("message", messageReceiver);
     window.addEventListener("beforeunload", onBeforeUnload);
 
+    window.dispatchEvent(new Event("ready"));
+
     return () => {
       window.removeEventListener("message", messageReceiver);
     };

--- a/apps/idos-enclave/src/pages/methods/Passkey.tsx
+++ b/apps/idos-enclave/src/pages/methods/Passkey.tsx
@@ -25,7 +25,7 @@ export default class Passkey extends React.Component<PasskeyProps> {
         onSuccess(result);
       }
 
-      store.set("preferred-auth-method", "webauthn");
+      store.set("preferred-auth-method", "passkey");
     } catch (e: any) {
       onError(e);
     }

--- a/apps/idos-example-dapp/src/main.js
+++ b/apps/idos-example-dapp/src/main.js
@@ -91,6 +91,7 @@ const connectWallet = {
   const idos = await idOS.init({
     enclaveOptions: {
       container: "#idos-container",
+      throwOnUserCancelUnlock: false,
     },
   });
   window.idos = idos;

--- a/packages/idos-sdk-js/src/lib/enclave-providers/iframe-enclave.ts
+++ b/packages/idos-sdk-js/src/lib/enclave-providers/iframe-enclave.ts
@@ -34,10 +34,14 @@ export class IframeEnclave implements EnclaveProvider {
 
     while (!encryptionPublicKey) {
       this.#showEnclave();
-      encryptionPublicKey = (await this.#requestToEnclave({ keys: {} })) as Uint8Array;
+      try {
+        encryptionPublicKey = (await this.#requestToEnclave({ keys: {} })) as Uint8Array;
+      } catch (e) {
+        if (this.options.throwOnUserCancelUnlock) throw e;
+      } finally {
+        this.#hideEnclave();
+      }
     }
-
-    this.#hideEnclave();
 
     return encryptionPublicKey;
   }

--- a/packages/idos-sdk-js/src/lib/enclave-providers/iframe-enclave.ts
+++ b/packages/idos-sdk-js/src/lib/enclave-providers/iframe-enclave.ts
@@ -32,10 +32,11 @@ export class IframeEnclave implements EnclaveProvider {
       storage: { humanId, signerAddress, signerPublicKey },
     })) as StoredData;
 
-    if (encryptionPublicKey) return encryptionPublicKey;
+    while (!encryptionPublicKey) {
+      this.#showEnclave();
+      encryptionPublicKey = (await this.#requestToEnclave({ keys: {} })) as Uint8Array;
+    }
 
-    this.#showEnclave();
-    encryptionPublicKey = (await this.#requestToEnclave({ keys: {} })) as Uint8Array;
     this.#hideEnclave();
 
     return encryptionPublicKey;

--- a/packages/idos-sdk-js/src/lib/enclave-providers/types.ts
+++ b/packages/idos-sdk-js/src/lib/enclave-providers/types.ts
@@ -10,6 +10,7 @@ export interface EnclaveOptions {
   theme?: "light" | "dark";
   mode?: "new" | "existing";
   url?: string;
+  throwOnUserCancelUnlock?: boolean;
 }
 
 export interface EnclaveProvider {


### PR DESCRIPTION
* if the enclave forgot the preferred auth method but had a credential id, we were opening the popup anyway
  * now we're trying to get passkey from the iframe before opening
* if the user chooses passkey in the enclave popup and it doesn't remember the credential id, we were causing passkey creation
  * now, we assume one must exist and ask the user to choose from a passkey list instead
  * only if none is chosen AND we're in "new user" mode do we create one

**Note:** I've seen this fail occasionally during development, where at the end of the popup journey, it wouldn't close. ~~Can't reproduce it anymore, but~~ please pay extra attention to this fact, it might ring a bell during the review.

**Edit:** the above seems to be fixed; now that the Enclave uses React, waiting for the popup's native `load` event was no longer sufficient to ensure it was listening