### PR TITLE
feat(example-dapp): prompt for timelock when creating a grant

### DIFF
--- a/apps/idos-example-dapp/src/main.js
+++ b/apps/idos-example-dapp/src/main.js
@@ -226,10 +226,13 @@ const connectWallet = {
           terminal.button(buttonId, "🔏 Acquire access grant", async () => {
             terminal.removeButton(buttonId);
 
-            const timelock = window.prompt(
-              "Please enter the grant timelock in seconds",
-              granteeInfo.lockTimeSpanSeconds,
-            );
+            let timelock =
+              window.prompt(
+                "Please enter the grant timelock in seconds",
+                granteeInfo.lockTimeSpanSeconds,
+              ) || granteeInfo.lockTimeSpanSeconds;
+
+            timelock = Number.isInteger(+timelock) ? timelock : granteeInfo.lockTimeSpanSeconds;
 
             const grantPromise = idos.grants.create(
               "credentials",


### PR DESCRIPTION
Prompt for a timelock whenever creating a `grant` in the `example-dapp`. It will default to `3600` if no value is provided.

This is needed mostly for e2e tests of the grants