### PR TITLE
fix: don't return all credentials

### DIFF
--- a/packages/idos-sdk-js/src/lib/data.ts
+++ b/packages/idos-sdk-js/src/lib/data.ts
@@ -18,7 +18,7 @@ export class Data {
     tableName: string,
     filter?: Partial<T>,
   ): Promise<T[]> {
-    const records = (await this.kwilWrapper.call(
+    let records = (await this.kwilWrapper.call(
       `get_${tableName}`,
       null,
       `List your ${tableName} in idOS`,
@@ -28,6 +28,10 @@ export class Data {
       for (const record of records) {
         record.value = await this.enclave.decrypt(record.value);
       }
+    }
+
+    if (tableName === "credentials") {
+      records = records.filter((record: any) => !record.original_id)
     }
 
     if (!filter) {


### PR DESCRIPTION
When an integrator needs to decide for which Credential to ask for an AG, they need to list the credentials.

However, currently, `idos.data.list("credentials")`, which is a tiny adapter over the `get_credentials` action on Kuniform, returns all the credentials about the user. Notably, and unfortunatly, this returns all the Credentials about the user, including copies that actually belong to an AG, and are not in direct control of the user. This makes `idos.data.list("credentials")` hard to use.

We should make our integrator's lives bearable, instead of forcing them to do some arbitrary filtering just because "that's what we came up with".

The solution to this problem is two-fold:
- As a stop-gap measure, do the filtering ourselves (this PR)
- The right solution is to do the right filtering on the get_credentials action (something for later)