### PR TITLE
feat: allow reconnections

### DIFF
--- a/packages/idos-sdk-js/src/lib/grants/grants.ts
+++ b/packages/idos-sdk-js/src/lib/grants/grants.ts
@@ -154,14 +154,6 @@ class ConnectedGrants extends Grants {
     this.#child = child;
   }
 
-  async connect(_args: {
-    type: SignerType;
-    signer: Wallet | Signer;
-    accountId?: string;
-  }): Promise<ConnectedGrants> {
-    throw new Error("Can't re-connect");
-  }
-
   async list(
     args: {
       owner?: string;


### PR DESCRIPTION
Checked it manually on playground by:
- Connecting some signer (with Metamask (MM))
- Check that everything works (list grants, etc)
- Change the connected address on MM
- Called `setSigner` again
- Things still work, and show data for the new address.