### PR TITLE
feat(idos-sdk): raise clearer exception in auth

### DIFF
--- a/packages/idos-sdk-js/src/__tests__/auth.test.ts
+++ b/packages/idos-sdk-js/src/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { Wallet } from "ethers";
-import { Auth } from "src/lib/auth";
+import { Auth, NoProfile } from "src/lib/auth";
 import { KwilWrapper } from "src/lib/kwil-wrapper";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { Store } from "../../../idos-store";
@@ -19,6 +19,7 @@ describe("auth", () => {
       id: humanId,
     });
     auth.kwilWrapper.client.auth.logout = vi.fn().mockResolvedValue(void 0);
+    auth.kwilWrapper.hasProfile = vi.fn().mockResolvedValue(true);
   });
 
   test("should create a new instance of Auth", () => {
@@ -40,6 +41,16 @@ describe("auth", () => {
       humanId,
       currentUserPublicKey,
       address,
+    });
+  });
+
+  describe("with an unknown user", () => {
+    test("should raise NoProfile", async () => {
+      auth.kwilWrapper.hasProfile = vi.fn().mockResolvedValueOnce(false);
+
+      const signer = Wallet.createRandom();
+
+      expect(() => auth.setEvmSigner(signer)).rejects.toThrowError(NoProfile);
     });
   });
 });

--- a/packages/idos-sdk-js/src/lib/auth.ts
+++ b/packages/idos-sdk-js/src/lib/auth.ts
@@ -19,6 +19,12 @@ export interface AuthUser {
   currentUserPublicKey?: string;
 }
 
+export class NoProfile extends Error {
+  constructor() {
+    super("Signer's address is not known to idOS.");
+  }
+}
+
 export class Auth {
   private user?: AuthUser;
 
@@ -42,6 +48,8 @@ export class Auth {
 
   async setEvmSigner(signer: Signer) {
     const currentAddress = await signer.getAddress();
+
+    if (!(await this.kwilWrapper.hasProfile(currentAddress))) throw new NoProfile();
 
     const storedAddress = this.store.get("signer-address");
 
@@ -72,6 +80,8 @@ export class Auth {
     if (!wallet.signMessage) throw new Error("Only wallets with signMessage are supported.");
 
     const currentAddress = (await wallet.getAccounts())[0].accountId;
+
+    if (!(await this.kwilWrapper.hasProfile(currentAddress))) throw new NoProfile();
 
     if (wallet.id === "my-near-wallet") {
       const { accountId, signature, publicKey, error } = Object.fromEntries(


### PR DESCRIPTION
Before:
```
Uncaught TypeError: Cannot destructure property 'current_public_key' of '(intermediate value)' as it is undefined.
```

After:
```
Uncaught NoProfile: Signer's address is not known to idOS.
```