### PR TITLE
feat: handle no `humanId` being passed at enclave dialog open

### DIFF
--- a/apps/idos-enclave/src/lib/enclave.js
+++ b/apps/idos-enclave/src/lib/enclave.js
@@ -57,7 +57,9 @@ export class Enclave {
     this.handlstoreableAttributes(litAttrs);
 
     const storeWithCodec = this.store.pipeCodec(Base64Codec);
+
     this.expectedUserEncryptionPublicKey = expectedUserEncryptionPublicKey;
+    this.humanId = humanId;
 
     if (!this.isAuthorizedOrigin) {
       return {
@@ -154,7 +156,7 @@ export class Enclave {
 
   async ensureKeyPair() {
     const password = this.store.get("password");
-    const salt = this.store.get("human-id");
+    const salt = this.humanId;
 
     const storeWithCodec = this.store.pipeCodec(Base64Codec);
 
@@ -397,6 +399,7 @@ export class Enclave {
   }
 
   async #openDialog(intent, message) {
+    if (!this.humanId) throw new Error("Can't open dialog without humanId");
     const width = 600;
     const height =
       this.configuration?.mode === "new" ? 600 : intent === "backupPasswordOrSecret" ? 520 : 400;
@@ -412,10 +415,7 @@ export class Enclave {
       .map((feat) => feat.join("="))
       .join(",");
 
-    const dialogURL = new URL(
-      `/dialog.html?humanId=${this.store.get("human-id")}`,
-      window.location.origin,
-    );
+    const dialogURL = new URL(`/dialog.html?humanId=${this.humanId}`, window.location.origin);
     this.dialog = window.open(dialogURL, "idos-dialog", popupConfig);
 
     await new Promise((resolve) => this.dialog.addEventListener("ready", resolve, { once: true }));

--- a/packages/issuer-sdk-js/README.md
+++ b/packages/issuer-sdk-js/README.md
@@ -72,7 +72,7 @@ Use the `idos.discoverEncryptionKey` function to derive a public key for the hum
 import { idOS } from "@idos-network/idos-sdk-js";
 
 // Arguments are described on idos-sdk-js's README. Be sure to read it.
-// Note: make sure to set mode to "new" since you're creating a new idos profile
+// Note: make sure to set mode to "new" since you're creating a new idOS profile
 const initParams = { ...YOUR_IDOS_INIT_PARAMS, mode: "new" };
 const idos = await idOS.init(...);
 

--- a/packages/issuer-sdk-js/README.md
+++ b/packages/issuer-sdk-js/README.md
@@ -72,6 +72,8 @@ Use the `idos.discoverEncryptionKey` function to derive a public key for the hum
 import { idOS } from "@idos-network/idos-sdk-js";
 
 // Arguments are described on idos-sdk-js's README. Be sure to read it.
+// Note: make sure to set mode to "new" since you're creating a new idos profile
+const initParams = { ...YOUR_IDOS_INIT_PARAMS, mode: "new" };
 const idos = await idOS.init(...);
 
 // Get humanId associated with this user from your server


### PR DESCRIPTION
---

### **How the Issue Occurs**  
The issue arises when the enclave store is cleared, either intentionally or unintentionally.  

---

### **Root Cause**  
The `humanId` value is essential as it is used as a salt in the `idosKeyDerivation` process. Without this value, the key derivation process fails, leading to the issue.  

---

### **Steps to Reproduce (Before the Fix)**  
1. Attempt to display content for one of your credentials.  
2. Clear the enclave's local storage after the Unlock button appears.  
3. Observe the failure when attempting to proceed.  

---

### **Resolution**  
1. `storage` method is invoked as soon as the Unlock button is displayed.  
2. The `humanId` is explicitly assigned to `this.humanId` within the function block, ensuring the value remains preserved within the `Enclave` class, even if the store is cleared.  
3. As an additional safeguard, an error is thrown if the `humanId` is not found when triggering the Unlock process.  

---
