### PR TITLE
chore(idos-sdk-js): Rename get_internal_ag_granted to get_access_grants_granted

### DIFF
--- a/packages/idos-sdk-js/src/lib/kwil-wrapper.ts
+++ b/packages/idos-sdk-js/src/lib/kwil-wrapper.ts
@@ -144,7 +144,7 @@ export class KwilWrapper {
   }
 
   async getGrantsGrantedCount(): Promise<number> {
-    const response = (await this.call("get_internal_ag_granted_count", null)) as unknown as {
+    const response = (await this.call("get_access_grants_granted_count", null)) as unknown as {
       count: number;
     }[];
     return response[0].count;
@@ -155,7 +155,7 @@ export class KwilWrapper {
     size = DEFAULT_RECORDS_PER_PAGE,
   ): Promise<{ grants: Grant[]; totalCount: number }> {
     if (!page) throw new Error("paging starts from 1");
-    const list = (await this.call("get_internal_ag_granted", { page, size })) as any;
+    const list = (await this.call("get_access_grants_granted", { page, size })) as any;
     const totalCount = await this.getGrantsGrantedCount();
 
     const grants = list.map(


### PR DESCRIPTION
## Reasoning

The schema is [changed](https://github.com/idos-network/idos-schema/pull/62), a few actions were renamed, so we need to reflect the changes in SDK.

