### PR TITLE
fix(data-dashboard): fix unlock button location

### DIFF
--- a/apps/idos-data-dashboard/index.html
+++ b/apps/idos-data-dashboard/index.html
@@ -14,7 +14,7 @@
 
   <style>
     #idos-root {
-      position: absolute;
+      position: fixed;
       width: 100%;
       height: 100%;
       top: 0;


### PR DESCRIPTION
In case you have less than 5 credentials. clicking on view credential and unlocking enclave won't be an issue.
but there's a problem when u have more than 5. so absolute would confuse you about location of un-lock enclave button. 
a position: fixed. fixed it 