### PR TITLE
chore: add missing entry

### DIFF
--- a/packages/issuer-sdk-js/tsup.config.ts
+++ b/packages/issuer-sdk-js/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "./src/create-issuer-config.ts",
     "./src/user.ts",
     "./src/credentials.ts",
+    "./src/grants.ts",
   ],
   splitting: false,
   sourcemap: true,


### PR DESCRIPTION
Show PR.

```bash
pkoch@bolota:~/github.com/idos-network/idos-sdk-js/packages/issuer-sdk-js
$ pnpx publint --strict
Running publint v0.3.6 for @idos-network/issuer-sdk-js...
Packing files with `pnpm pack`...
Linting...
Errors:
1. pkg.exports["./grants"].types is ./dist/grants.d.ts but the file does not exist.
2. pkg.exports["./grants"].import is ./dist/grants.js but the file does not exist.
```