### PR TITLE
feat: dont export kwil actions on root

### DIFF
--- a/examples/consumer-and-issuer/src/components/onboarding.tsx
+++ b/examples/consumer-and-issuer/src/components/onboarding.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, useDisclosure } from "@heroui/react";
-import { createAttribute, getAttributes } from "@idos-network/core";
+import { createAttribute, getAttributes } from "@idos-network/core/kwil-actions";
 import {
   type IssuerConfig,
   createIssuerConfig,

--- a/packages/@controllers/src/isle/index.ts
+++ b/packages/@controllers/src/isle/index.ts
@@ -1,5 +1,4 @@
 import {
-  type DelegatedWriteGrantSignatureRequest,
   type EnclaveOptions,
   type EnclaveProvider,
   IframeEnclave,
@@ -10,25 +9,28 @@ import {
   type IsleTheme,
   type KwilActionClient,
   Store,
-  getUserProfile as _getUserProfile,
-  shareCredential as _shareCredential,
   base64Decode,
   base64Encode,
   buildInsertableIDOSCredential,
   createFrontendKwilSigner,
   createWebKwilClient,
+  type idOSCredential,
+  type idOSUser,
+  utf8Decode,
+  utf8Encode,
+} from "@idos-network/core";
+import {
+  type DelegatedWriteGrantSignatureRequest,
+  getUserProfile as _getUserProfile,
+  shareCredential as _shareCredential,
   getAccessGrantsOwned,
   getAllCredentials,
   getCredentialById,
   getCredentialOwned,
   hasProfile,
-  type idOSCredential,
-  type idOSUser,
   removeCredential,
   requestDWGMessage,
-  utf8Decode,
-  utf8Encode,
-} from "@idos-network/core";
+} from "@idos-network/core/kwil-actions";
 import { type ChannelInstance, type Controller, createController } from "@sanity/comlink";
 import {
   http,

--- a/packages/@core/src/index.ts
+++ b/packages/@core/src/index.ts
@@ -3,7 +3,6 @@ export * from "./codecs";
 export * from "./cryptography";
 export * from "./types";
 export * from "./kwil-nep413-signer";
-export * from "./kwil-actions";
 export * from "./kwil-infra";
 export * from "./store";
 export * from "./utils";

--- a/packages/consumer-sdk-js/src/client/credentials.ts
+++ b/packages/consumer-sdk-js/src/client/credentials.ts
@@ -1,13 +1,15 @@
 import {
-  createCredentialCopy as _createCredentialCopy,
-  getAllCredentials as _getAllCredentials,
-  getCredentialById as _getCredentialById,
   base64Decode,
   base64Encode,
   buildInsertableIDOSCredential,
   hexEncodeSha256Hash,
   utf8Encode,
 } from "@idos-network/core";
+import {
+  createCredentialCopy as _createCredentialCopy,
+  getAllCredentials as _getAllCredentials,
+  getCredentialById as _getCredentialById,
+} from "@idos-network/core/kwil-actions";
 import invariant from "tiny-invariant";
 import type { ConsumerConfig } from "./create-consumer-config";
 

--- a/packages/consumer-sdk-js/src/client/grants.ts
+++ b/packages/consumer-sdk-js/src/client/grants.ts
@@ -1,7 +1,7 @@
 import {
   requestDAGMessage as _requestDAGMessage,
   type idOSDAGSignatureParams,
-} from "@idos-network/core";
+} from "@idos-network/core/kwil-actions";
 import type { ConsumerConfig } from "./create-consumer-config";
 
 /**

--- a/packages/consumer-sdk-js/src/client/user.ts
+++ b/packages/consumer-sdk-js/src/client/user.ts
@@ -1,4 +1,4 @@
-import { getUserProfile as _getUserProfile, hasProfile } from "@idos-network/core";
+import { getUserProfile as _getUserProfile, hasProfile } from "@idos-network/core/kwil-actions";
 import type { ConsumerConfig } from "./create-consumer-config";
 
 /**

--- a/packages/issuer-sdk-js/src/client/user.ts
+++ b/packages/issuer-sdk-js/src/client/user.ts
@@ -3,7 +3,7 @@ import {
   getUserProfile as _getUserProfile,
   hasProfile as _hasProfile,
   requestDWGMessage as _requestDWGMessage,
-} from "@idos-network/core";
+} from "@idos-network/core/kwil-actions";
 import type { IssuerConfig } from "./create-issuer-config";
 
 export async function hasProfile({ kwilClient, userAddress }: IssuerConfig) {

--- a/packages/issuer-sdk-js/src/server/credentials.ts
+++ b/packages/issuer-sdk-js/src/server/credentials.ts
@@ -1,10 +1,4 @@
 import {
-  type CreateCredentialByDelegatedWriteGrantParams,
-  createCredentialAsInserter as _createCredentialAsInserter,
-  createCredentialByDelegatedWriteGrant as _createCredentialByDelegatedWriteGrant,
-  editCredentialAsIssuer as _editCredentialAsIssuer,
-  getCredentialIdByContentHash as _getCredentialIdByContentHash,
-  getSharedCredential as _getSharedCredential,
   base64Decode,
   base64Encode,
   encryptContent,
@@ -13,6 +7,14 @@ import {
   type idOSCredential,
   utf8Encode,
 } from "@idos-network/core";
+import {
+  type CreateCredentialByDelegatedWriteGrantParams,
+  createCredentialAsInserter as _createCredentialAsInserter,
+  createCredentialByDelegatedWriteGrant as _createCredentialByDelegatedWriteGrant,
+  editCredentialAsIssuer as _editCredentialAsIssuer,
+  getCredentialIdByContentHash as _getCredentialIdByContentHash,
+  getSharedCredential as _getSharedCredential,
+} from "@idos-network/core/kwil-actions";
 import nacl from "tweetnacl";
 import type { IssuerConfig } from "./create-issuer-config";
 import { ensureEntityId } from "./internal";

--- a/packages/issuer-sdk-js/src/server/grants.ts
+++ b/packages/issuer-sdk-js/src/server/grants.ts
@@ -1,9 +1,5 @@
-import {
-  createAccessGrantByDag as _createAccessGrantByDag,
-  base64Decode,
-  decryptContent,
-  hexEncodeSha256Hash,
-} from "@idos-network/core";
+import { base64Decode, decryptContent, hexEncodeSha256Hash } from "@idos-network/core";
+import { createAccessGrantByDag as _createAccessGrantByDag } from "@idos-network/core/kwil-actions";
 import nacl from "tweetnacl";
 import type { IssuerConfig } from "./create-issuer-config";
 import { getCredentialIdByContentHash, getSharedCredential } from "./credentials";

--- a/packages/issuer-sdk-js/src/server/user.ts
+++ b/packages/issuer-sdk-js/src/server/user.ts
@@ -1,9 +1,8 @@
+import type { idOSUser, idOSWallet } from "@idos-network/core";
 import {
   createUser as _createUser,
   upsertWalletAsInserter as _upsertWalletAsInserter,
-  type idOSUser,
-  type idOSWallet,
-} from "@idos-network/core";
+} from "@idos-network/core/kwil-actions";
 import type { IssuerConfig } from "./create-issuer-config";
 import { ensureEntityId } from "./internal";
 


### PR DESCRIPTION
cc @Mohammed-Mamoun98 

Force modules that use kwil-actions to import from it directly. This way, we can see what abstractions are currently leaking.