### PR TITLE
feat: more explicit config names

### DIFF
--- a/examples/consumer-and-issuer/src/components/onboarding.tsx
+++ b/examples/consumer-and-issuer/src/components/onboarding.tsx
@@ -3,8 +3,8 @@
 import { Button, useDisclosure } from "@heroui/react";
 import { createAttribute, getAttributes } from "@idos-network/core/kwil-actions";
 import {
-  type IssuerConfig,
-  createIssuerConfig,
+  type IssuerClientConfig,
+  createIssuerClientConfig,
   getUserEncryptionPublicKey,
   getUserProfile,
   hasProfile,
@@ -31,7 +31,10 @@ const enclaveOptions = {
 
 type IdvTicket = { idvUserId: string; idOSUserId: string; signature: string };
 
-const useFetchUserData = (config: IssuerConfig | undefined, signer: JsonRpcSigner | undefined) => {
+const useFetchUserData = (
+  config: IssuerClientConfig | undefined,
+  signer: JsonRpcSigner | undefined,
+) => {
   return useQuery({
     queryKey: ["user-data"],
     queryFn: async () => {
@@ -100,7 +103,7 @@ export const useCreateIDVAttribute = () => {
       idOSUserId: string;
       idvUserId: string;
       signature: string;
-      config: IssuerConfig;
+      config: IssuerClientConfig;
     }) => {
       const { idOSUserId, idvUserId, signature, config } = data;
 
@@ -195,13 +198,13 @@ const STEPPER_ACTIVE_INDEX = {
   verified: 4,
 };
 
-function useIssuerConfig(signer: JsonRpcSigner | undefined) {
-  const [config, setConfig] = useState<IssuerConfig | undefined>(undefined);
+function useIssuerClientConfig(signer: JsonRpcSigner | undefined) {
+  const [config, setConfig] = useState<IssuerClientConfig | undefined>(undefined);
   useEffect(() => {
     if (!signer) return;
 
     const initialize = async () => {
-      const _config = await createIssuerConfig({
+      const _config = await createIssuerClientConfig({
         nodeUrl: process.env.NEXT_PUBLIC_KWIL_NODE_URL ?? "",
         signer,
         enclaveOptions,
@@ -222,7 +225,7 @@ export function Onboarding() {
   const { address } = useAccount();
 
   const signer = useEthersSigner();
-  const config = useIssuerConfig(signer);
+  const config = useIssuerClientConfig(signer);
   const userData = useFetchUserData(config, signer);
   const idvStatus = useFetchIDVStatus(userData.data);
   const createIDVAttribute = useCreateIDVAttribute();

--- a/examples/consumer-and-issuer/src/issuer.config.ts
+++ b/examples/consumer-and-issuer/src/issuer.config.ts
@@ -1,11 +1,14 @@
 import { base64Decode } from "@idos-network/core";
-import { type IssuerConfig, createIssuerConfig } from "@idos-network/issuer-sdk-js/server";
+import {
+  type IssuerServerConfig,
+  createIssuerServerConfig,
+} from "@idos-network/issuer-sdk-js/server";
 import invariant from "tiny-invariant";
 import nacl from "tweetnacl";
 
-let cachedIssuer: IssuerConfig | null = null;
+let cachedIssuer: IssuerServerConfig | null = null;
 
-export async function getIssuerConfig(): Promise<IssuerConfig> {
+export async function getIssuerConfig(): Promise<IssuerServerConfig> {
   if (cachedIssuer) {
     return cachedIssuer;
   }
@@ -18,7 +21,7 @@ export async function getIssuerConfig(): Promise<IssuerConfig> {
   invariant(ENCRYPTION_SECRET_KEY, "`NEXT_ISSUER_ENCRYPTION_SECRET_KEY` is not set");
   invariant(SIGNING_SECRET_KEY, "`NEXT_ISSUER_SIGNING_SECRET_KEY` is not set");
 
-  cachedIssuer = await createIssuerConfig({
+  cachedIssuer = await createIssuerServerConfig({
     nodeUrl: NODE_URL,
     signingKeyPair: nacl.sign.keyPair.fromSecretKey(base64Decode(SIGNING_SECRET_KEY)),
     encryptionSecretKey: base64Decode(ENCRYPTION_SECRET_KEY),

--- a/examples/passporting/src/idOS.provider.tsx
+++ b/examples/passporting/src/idOS.provider.tsx
@@ -2,9 +2,9 @@
 
 import { Button, CircularProgress, Link } from "@heroui/react";
 import {
-  type ConsumerConfig,
+  type ConsumerClientConfig,
   checkUserProfile,
-  createConsumerConfig,
+  createConsumerClientConfig,
 } from "@idos-network/consumer-sdk-js/client";
 import {
   type PropsWithChildren,
@@ -21,11 +21,11 @@ import { useAccount } from "wagmi";
 import { useEthersSigner } from "@/wagmi.config";
 
 // biome-ignore lint/style/noNonNullAssertion: because it's initialized in the provider.
-export const idOSConsumerContext = createContext<ConsumerConfig>(null!);
+export const idOSConsumerContext = createContext<ConsumerClientConfig>(null!);
 export const useIdOSConsumer = () => useContext(idOSConsumerContext);
 
 export function IDOSConsumerProvider({ children }: PropsWithChildren) {
-  const [config, setConfig] = useState<ConsumerConfig | null>(null);
+  const [config, setConfig] = useState<ConsumerClientConfig | null>(null);
   const [initializing, setInitializing] = useState(true);
   const initialized = useRef(false);
 
@@ -40,7 +40,7 @@ export function IDOSConsumerProvider({ children }: PropsWithChildren) {
 
     initialized.current = true;
 
-    const _config = await createConsumerConfig({
+    const _config = await createConsumerClientConfig({
       nodeUrl: process.env.NEXT_PUBLIC_KWIL_NODE_URL ?? "",
       signer,
       enclaveOptions: {

--- a/packages/consumer-sdk-js/src/client/create-consumer-client-config.ts
+++ b/packages/consumer-sdk-js/src/client/create-consumer-client-config.ts
@@ -7,14 +7,14 @@ import {
   createWebKwilClient,
 } from "@idos-network/core";
 
-type CreateConsumerConfigParams = {
+type CreateConsumerClientConfigParams = {
   chainId?: string;
   nodeUrl: string;
   signer: Wallet;
   enclaveOptions: Omit<EnclaveOptions, "mode">;
 };
 
-export async function createConsumerConfig(params: CreateConsumerConfigParams) {
+export async function createConsumerClientConfig(params: CreateConsumerClientConfigParams) {
   const store = new Store(window.localStorage);
 
   const kwilClient = await createWebKwilClient({
@@ -35,4 +35,4 @@ export async function createConsumerConfig(params: CreateConsumerConfigParams) {
   };
 }
 
-export type ConsumerConfig = Awaited<ReturnType<typeof createConsumerConfig>>;
+export type ConsumerClientConfig = Awaited<ReturnType<typeof createConsumerClientConfig>>;

--- a/packages/consumer-sdk-js/src/client/credentials.ts
+++ b/packages/consumer-sdk-js/src/client/credentials.ts
@@ -11,26 +11,29 @@ import {
   getCredentialById as _getCredentialById,
 } from "@idos-network/core/kwil-actions";
 import invariant from "tiny-invariant";
-import type { ConsumerConfig } from "./create-consumer-config";
+import type { ConsumerClientConfig } from "./create-consumer-client-config";
 
 /**
  * Get all idOSCredentials for the given consumer
  */
-export async function getAllCredentials({ kwilClient }: ConsumerConfig) {
+export async function getAllCredentials({ kwilClient }: ConsumerClientConfig) {
   return _getAllCredentials(kwilClient);
 }
 
 /**
  * Get an idOSCredential by its `id`
  */
-export async function getCredentialById({ kwilClient }: ConsumerConfig, id: string) {
+export async function getCredentialById({ kwilClient }: ConsumerClientConfig, id: string) {
   return _getCredentialById(kwilClient, id);
 }
 
 /**
  * Get the SHA256 hash of the content of an idOSCredential
  */
-export async function getCredentialContentSha256Hash({ kwilClient }: ConsumerConfig, id: string) {
+export async function getCredentialContentSha256Hash(
+  { kwilClient }: ConsumerClientConfig,
+  id: string,
+) {
   const credential = await _getCredentialById(kwilClient, id);
 
   invariant(credential, `"idOSCredential" with id ${id} not found`);
@@ -43,7 +46,7 @@ export async function getCredentialContentSha256Hash({ kwilClient }: ConsumerCon
  * This doesn't create an Access Grant and is used only for passporting flows
  */
 export async function createCredentialCopy(
-  { enclaveProvider, kwilClient }: ConsumerConfig,
+  { enclaveProvider, kwilClient }: ConsumerClientConfig,
   id: string,
   consumerRecipientEncryptionPublicKey: string,
   consumerInfo: {

--- a/packages/consumer-sdk-js/src/client/grants.ts
+++ b/packages/consumer-sdk-js/src/client/grants.ts
@@ -2,13 +2,13 @@ import {
   requestDAGMessage as _requestDAGMessage,
   type idOSDAGSignatureParams,
 } from "@idos-network/core/kwil-actions";
-import type { ConsumerConfig } from "./create-consumer-config";
+import type { ConsumerClientConfig } from "./create-consumer-client-config";
 
 /**
  * Request a signature for a Delegated Access Grant
  */
 export async function requestDAGMessage(
-  { kwilClient }: ConsumerConfig,
+  { kwilClient }: ConsumerClientConfig,
   params: idOSDAGSignatureParams,
 ) {
   return _requestDAGMessage(kwilClient, params);

--- a/packages/consumer-sdk-js/src/client/index.ts
+++ b/packages/consumer-sdk-js/src/client/index.ts
@@ -1,4 +1,4 @@
-export * from "./create-consumer-config";
+export * from "./create-consumer-client-config";
 export * from "./credentials";
 export * from "./grants";
 export * from "./user";

--- a/packages/consumer-sdk-js/src/client/user.ts
+++ b/packages/consumer-sdk-js/src/client/user.ts
@@ -1,16 +1,16 @@
 import { getUserProfile as _getUserProfile, hasProfile } from "@idos-network/core/kwil-actions";
-import type { ConsumerConfig } from "./create-consumer-config";
+import type { ConsumerClientConfig } from "./create-consumer-client-config";
 
 /**
  * Check if a user has a profile in the idOS by the given `address`
  */
-export async function checkUserProfile({ kwilClient }: ConsumerConfig, address: string) {
+export async function checkUserProfile({ kwilClient }: ConsumerClientConfig, address: string) {
   return hasProfile(kwilClient, address);
 }
 
 /**
  * Get the profile of the current user.
  */
-export async function getUserProfile({ kwilClient }: ConsumerConfig) {
+export async function getUserProfile({ kwilClient }: ConsumerClientConfig) {
   return _getUserProfile(kwilClient);
 }

--- a/packages/issuer-sdk-js/src/client/create-issuer-client-config.ts
+++ b/packages/issuer-sdk-js/src/client/create-issuer-client-config.ts
@@ -7,14 +7,14 @@ import {
   createWebKwilClient,
 } from "@idos-network/core";
 
-type CreateIssuerConfigParams = {
+type CreateIssuerClientConfigParams = {
   chainId?: string;
   nodeUrl: string;
   signer: Wallet;
   enclaveOptions: Omit<EnclaveOptions, "mode">;
 };
 
-export async function createIssuerConfig(params: CreateIssuerConfigParams) {
+export async function createIssuerClientConfig(params: CreateIssuerClientConfigParams) {
   const store = new Store(window.localStorage);
 
   const kwilClient = await createWebKwilClient({
@@ -39,4 +39,4 @@ export async function createIssuerConfig(params: CreateIssuerConfigParams) {
   };
 }
 
-export type IssuerConfig = Awaited<ReturnType<typeof createIssuerConfig>>;
+export type IssuerClientConfig = Awaited<ReturnType<typeof createIssuerClientConfig>>;

--- a/packages/issuer-sdk-js/src/client/credentials.ts
+++ b/packages/issuer-sdk-js/src/client/credentials.ts
@@ -3,9 +3,9 @@ import {
   getCredentialById,
 } from "@idos-network/core/kwil-actions";
 import invariant from "tiny-invariant";
-import type { IssuerConfig } from "./create-issuer-config";
+import type { IssuerClientConfig } from "./create-issuer-client-config";
 
-export async function shareCredential({ kwilClient }: IssuerConfig, id: string) {
+export async function shareCredential({ kwilClient }: IssuerClientConfig, id: string) {
   const credential = await getCredentialById(kwilClient, id);
   invariant(credential, `"idOSCredential" with id ${id} not found`);
 

--- a/packages/issuer-sdk-js/src/client/index.ts
+++ b/packages/issuer-sdk-js/src/client/index.ts
@@ -1,2 +1,2 @@
-export * from "./create-issuer-config";
+export * from "./create-issuer-client-config";
 export * from "./user";

--- a/packages/issuer-sdk-js/src/client/user.ts
+++ b/packages/issuer-sdk-js/src/client/user.ts
@@ -4,20 +4,20 @@ import {
   hasProfile as _hasProfile,
   requestDWGMessage as _requestDWGMessage,
 } from "@idos-network/core/kwil-actions";
-import type { IssuerConfig } from "./create-issuer-config";
+import type { IssuerClientConfig } from "./create-issuer-client-config";
 
-export async function hasProfile({ kwilClient, userAddress }: IssuerConfig) {
+export async function hasProfile({ kwilClient, userAddress }: IssuerClientConfig) {
   return _hasProfile(kwilClient, userAddress);
 }
 
 export async function requestDWGMessage(
-  { kwilClient }: IssuerConfig,
+  { kwilClient }: IssuerClientConfig,
   params: DelegatedWriteGrantSignatureRequest,
 ) {
   return _requestDWGMessage(kwilClient, params);
 }
 
-export async function getUserProfile({ kwilClient }: IssuerConfig) {
+export async function getUserProfile({ kwilClient }: IssuerClientConfig) {
   const user = await _getUserProfile(kwilClient);
   return user;
 }
@@ -26,7 +26,7 @@ export async function getUserProfile({ kwilClient }: IssuerConfig) {
  * Get the public key of the user's encryption key
  */
 export async function getUserEncryptionPublicKey(
-  { enclaveProvider }: IssuerConfig,
+  { enclaveProvider }: IssuerClientConfig,
   userId: string,
 ) {
   return await enclaveProvider.discoverUserEncryptionPublicKey(userId);

--- a/packages/issuer-sdk-js/src/server/create-issuer-server-config.test.ts
+++ b/packages/issuer-sdk-js/src/server/create-issuer-server-config.test.ts
@@ -3,7 +3,7 @@ import { NodeKwil } from "@kwilteam/kwil-js";
 import nacl from "tweetnacl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createIssuerConfig } from "./create-issuer-config";
+import { createIssuerServerConfig } from "./create-issuer-server-config";
 
 // Mock the @kwilteam/kwil-js module
 vi.mock("@kwilteam/kwil-js", () => {
@@ -37,7 +37,7 @@ describe("createIssuerConfig", () => {
       timeout: 30_000,
     };
 
-    const result = await createIssuerConfig(params);
+    const result = await createIssuerServerConfig(params);
 
     // Check if NodeKwil was called correctly
     expect(NodeKwil).toHaveBeenCalledWith({

--- a/packages/issuer-sdk-js/src/server/create-issuer-server-config.ts
+++ b/packages/issuer-sdk-js/src/server/create-issuer-server-config.ts
@@ -4,20 +4,22 @@ import {
   createNodeKwilClient,
 } from "@idos-network/core";
 
-export interface IssuerConfig {
+export interface IssuerServerConfig {
   kwilClient: KwilActionClient;
   signingKeyPair: nacl.SignKeyPair;
   encryptionSecretKey: Uint8Array;
 }
 
-type CreateIssuerConfigParams = {
+type CreateIssuerServerConfigParams = {
   chainId?: string;
   nodeUrl: string;
   signingKeyPair: nacl.SignKeyPair;
   encryptionSecretKey: Uint8Array;
 };
 
-export async function createIssuerConfig(params: CreateIssuerConfigParams): Promise<IssuerConfig> {
+export async function createIssuerServerConfig(
+  params: CreateIssuerServerConfigParams,
+): Promise<IssuerServerConfig> {
   const kwilClient = await createNodeKwilClient({
     nodeUrl: params.nodeUrl,
     chainId: params.chainId,

--- a/packages/issuer-sdk-js/src/server/credentials.ts
+++ b/packages/issuer-sdk-js/src/server/credentials.ts
@@ -16,7 +16,7 @@ import {
   getSharedCredential as _getSharedCredential,
 } from "@idos-network/core/kwil-actions";
 import nacl from "tweetnacl";
-import type { IssuerConfig } from "./create-issuer-config";
+import type { IssuerServerConfig } from "./create-issuer-server-config";
 import { ensureEntityId } from "./internal";
 
 type InsertableIDOSCredential = Omit<idOSCredential, "id" | "original_id"> & {
@@ -34,15 +34,15 @@ type BuildInsertableIDOSCredentialArgs = {
 };
 
 function buildInsertableIDOSCredential(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   args: BuildInsertableIDOSCredentialArgs,
 ): InsertableIDOSCredential;
 function buildInsertableIDOSCredential(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   args: Omit<BuildInsertableIDOSCredentialArgs, "userId">,
 ): Omit<InsertableIDOSCredential, "user_id">;
 function buildInsertableIDOSCredential(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   {
     userId,
     publicNotes,
@@ -88,7 +88,7 @@ export interface BaseCredentialParams {
 }
 
 export async function createCredentialAsInserter(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   params: BaseCredentialParams,
 ): Promise<idOSCredential> {
   const { kwilClient } = issuerConfig;
@@ -116,7 +116,7 @@ export interface DelegatedWriteGrantParams {
 }
 
 export async function createCredentialByDelegatedWriteGrant(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   credentialParams: DelegatedWriteGrantBaseParams,
   delegatedWriteGrant: DelegatedWriteGrantParams,
 ): Promise<{
@@ -171,7 +171,7 @@ interface EditCredentialAsIssuerParams {
   publicNotes: string;
 }
 export async function editCredentialAsIssuer(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   { publicNotesId, publicNotes }: EditCredentialAsIssuerParams,
 ) {
   const { kwilClient } = issuerConfig;
@@ -186,7 +186,7 @@ export async function editCredentialAsIssuer(
 }
 
 export async function getCredentialIdByContentHash(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   contentHash: string,
 ): Promise<string | null> {
   const { kwilClient } = issuerConfig;
@@ -196,7 +196,7 @@ export async function getCredentialIdByContentHash(
   return id ?? null;
 }
 
-export async function getSharedCredential(issuerConfig: IssuerConfig, id: string) {
+export async function getSharedCredential(issuerConfig: IssuerServerConfig, id: string) {
   const { kwilClient } = issuerConfig;
 
   const result = await _getSharedCredential(kwilClient, id);

--- a/packages/issuer-sdk-js/src/server/grants.ts
+++ b/packages/issuer-sdk-js/src/server/grants.ts
@@ -1,7 +1,7 @@
 import { base64Decode, decryptContent, hexEncodeSha256Hash } from "@idos-network/core";
 import { createAccessGrantByDag as _createAccessGrantByDag } from "@idos-network/core/kwil-actions";
 import nacl from "tweetnacl";
-import type { IssuerConfig } from "./create-issuer-config";
+import type { IssuerServerConfig } from "./create-issuer-server-config";
 import { getCredentialIdByContentHash, getSharedCredential } from "./credentials";
 
 interface CreateAccessGrantFromDAGParams {
@@ -14,7 +14,7 @@ interface CreateAccessGrantFromDAGParams {
 }
 
 export async function createAccessGrantFromDAG(
-  issuerConfig: IssuerConfig,
+  issuerConfig: IssuerServerConfig,
   params: CreateAccessGrantFromDAGParams,
 ) {
   const { kwilClient } = issuerConfig;

--- a/packages/issuer-sdk-js/src/server/index.ts
+++ b/packages/issuer-sdk-js/src/server/index.ts
@@ -1,4 +1,4 @@
-export * from "./create-issuer-config";
+export * from "./create-issuer-server-config";
 export * from "./credentials";
 export * from "./grants";
 export * from "./user";

--- a/packages/issuer-sdk-js/src/server/user.ts
+++ b/packages/issuer-sdk-js/src/server/user.ts
@@ -3,7 +3,7 @@ import {
   createUser as _createUser,
   upsertWalletAsInserter as _upsertWalletAsInserter,
 } from "@idos-network/core/kwil-actions";
-import type { IssuerConfig } from "./create-issuer-config";
+import type { IssuerServerConfig } from "./create-issuer-server-config";
 import { ensureEntityId } from "./internal";
 
 export interface CreateProfileReqParams extends Omit<idOSUser, "id"> {
@@ -11,7 +11,7 @@ export interface CreateProfileReqParams extends Omit<idOSUser, "id"> {
 }
 
 export async function createUserProfile(
-  { kwilClient }: IssuerConfig,
+  { kwilClient }: IssuerServerConfig,
   params: CreateProfileReqParams,
 ): Promise<idOSUser> {
   const payload = ensureEntityId(params);
@@ -25,7 +25,7 @@ export interface UpsertWalletReqParams extends Omit<idOSWallet, "id"> {
 }
 
 export async function upsertWalletAsInserter(
-  { kwilClient }: IssuerConfig,
+  { kwilClient }: IssuerServerConfig,
   params: UpsertWalletReqParams,
 ): Promise<idOSWallet> {
   const payload = ensureEntityId(params);
@@ -37,7 +37,7 @@ export async function upsertWalletAsInserter(
 export interface CreateWalletReqParams extends Omit<UpsertWalletReqParams, "user_id"> {}
 
 export async function createUser(
-  config: IssuerConfig,
+  config: IssuerServerConfig,
   user: CreateProfileReqParams,
   wallet: CreateWalletReqParams,
 ) {


### PR DESCRIPTION
CC @Mohammed-Mamoun98 

Show PR. I was getting too confused with the two different `IssuerConfig` for each SDK, so I gave them more explicit names.