### PR TITLE
fix: use isle buildIssuerClientConfig

### DIFF
--- a/packages/@controllers/package.json
+++ b/packages/@controllers/package.json
@@ -10,6 +10,7 @@
     "go-try": "^3.0.2"
   },
   "devDependencies": {
+    "@kwilteam/kwil-js": "catalog:",
     "tiny-invariant": "^1.3.3"
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
     devDependencies:
+      '@kwilteam/kwil-js':
+        specifier: 'catalog:'
+        version: 0.9.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3


### PR DESCRIPTION
This was me trying to reuse the object from the isle controller. However, I'm getting this:
```
Uncaught (in promise) Error: Invariant failed: `idOSProfile` not found
    at invariant (tiny-invariant.js:12:11)
    at Onboarding.useCallback[handleKYCSuccess] (onboarding.tsx:302:15)
    at KYCJourney.useCallback[messageReceiver] (kyc-journey.tsx:23:11)
```