### PR TITLE
fix: don't clear the enclave on logoff

### DIFF
--- a/packages/@core/src/client/index.ts
+++ b/packages/@core/src/client/index.ts
@@ -130,7 +130,6 @@ export class idOSClientWithUserSigner implements Omit<Properties<idOSClientIdle>
 
   async logOut(): Promise<idOSClientIdle> {
     this.kwilClient.setSigner(undefined);
-    await this.enclaveProvider.reset();
     return new idOSClientIdle(this.store, this.kwilClient, this.enclaveProvider);
   }
 
@@ -178,7 +177,6 @@ export class idOSClientLoggedIn implements Omit<Properties<idOSClientWithUserSig
 
   async logOut(): Promise<idOSClientIdle> {
     this.kwilClient.setSigner(undefined);
-    await this.enclaveProvider.reset();
     return new idOSClientIdle(this.store, this.kwilClient, this.enclaveProvider);
   }
 


### PR DESCRIPTION
The enclave now forgets its storage once we ready it with a different user than what it has in its storage.

I'm not in love with the fact that this can be abused to call methods that decrypt things for a user that was "logged off", since the enclave is still gonna feel ready. Unsure how to untangle that knot, maybe we need a new storage field on the enclave to denote if it should accept encryption operations (i.e., it it's ready or disarmed) but still preserve memory until it sees a new user.