### PR TITLE
fix(passporting-server): dynamicly import ripple key pairs

### DIFF
--- a/apps/passporting-server/src/core.js
+++ b/apps/passporting-server/src/core.js
@@ -7,7 +7,6 @@ import { Hono } from "hono";
 import { env } from "hono/adapter";
 import nacl from "tweetnacl";
 import { z } from "zod";
-import * as xrpKeypair from "ripple-keypairs";
 
 const app = new Hono();
 
@@ -166,6 +165,9 @@ app.post(
       // Convert base64 to hex strings for ripple-keypairs
       const messageHex = hexEncode(base64Decode(message));
       const signatureHex = hexEncode(base64Decode(signature));
+
+      // Dynamic import to avoid CommonJS/ES module conflict
+      const xrpKeypair = await import("ripple-keypairs");
       isValid = xrpKeypair.verify(messageHex, signatureHex, signerPublicKey);
     } else {
       // Use nacl for other signature types

--- a/examples/pay-demo/app/providers/noah.server.ts
+++ b/examples/pay-demo/app/providers/noah.server.ts
@@ -168,7 +168,6 @@ export async function createNoahCustomer(address: string, credentials: Credentia
     body: JSON.stringify(subject),
   });
 
-
   if (!response.ok) {
     const text = await response.text();
     console.error("Noah error:", text);

--- a/examples/pay-demo/app/routes/app.tsx
+++ b/examples/pay-demo/app/routes/app.tsx
@@ -207,7 +207,7 @@ export default function App() {
         <p>{messages[state.createSharableToken as keyof typeof messages]}</p>
         {errorMessage && <p className="text-red-500">{errorMessage}</p>}
       </div>
-    )
+    );
   }
 
   if (state === "dataOrTokenFetched" && noahUrl && provider === "noah") {


### PR DESCRIPTION
# Fix ES Module Compatibility Issue with ripple-keypairs

## Problem
The passporting-server was failing on Vercel with the error:
```
ReferenceError: exports is not defined in ES module scope
```

This occurred because the `ripple-keypairs` package uses CommonJS syntax (`exports`, `require`) but was being imported in an ES module context.

## Solution
Replaced the static import of `ripple-keypairs` with a dynamic import to avoid the CommonJS/ES module conflict:

```javascript
// Before
import * as xrpKeypair from "ripple-keypairs";

// After  
const xrpKeypair = await import("ripple-keypairs");
```

## Changes
- **File**: `apps/passporting-server/src/core.js`
- **Line**: 158 - Replaced static import with dynamic import in the XRPL signature verification logic

This fix ensures compatibility with Vercel's ES module environment while maintaining the same functionality for XRPL signature verification.