### PR TITLE
fix/remove inlineDynamicImports flag from issuer tsdown.config

### DIFF
--- a/packages/issuer/tsdown.config.ts
+++ b/packages/issuer/tsdown.config.ts
@@ -11,7 +11,4 @@ export default defineConfig({
     "jsonld-document-loader",
     "web-streams-polyfill",
   ],
-  outputOptions: {
-    inlineDynamicImports: true,
-  },
 });


### PR DESCRIPTION
The key issue appears to be the `inlineDynamicImports: true` setting in your `tsdown.config.ts` This option was causing the bundler to absorb the ripple-keypairs code directly into your package, which re-introduced the CommonJS/ESM conflict no matter how we imported it.